### PR TITLE
add alliance label to nats message

### DIFF
--- a/src/nats/message.ts
+++ b/src/nats/message.ts
@@ -36,7 +36,7 @@ function message(action, requestedProject) {
       default:
         return 'none';
     }
-  });//ministry as string).toLocaleLowerCase() == 'ag' ? "JAG" : "none";
+  });
 
   const primaryTechnicalLeadContact = {
     user_id: primaryTechnicalLead.githubId,

--- a/src/nats/message.ts
+++ b/src/nats/message.ts
@@ -26,17 +26,18 @@ function message(action, requestedProject) {
     role: "owner"
   };
 
-  const allianceLabel = (() => {
-    switch ((ministry as string).toLocaleLowerCase()) {
-      case 'ag':
-      case 'pssg':
-      case 'embc':
-      case 'mah':
-        return 'JAG';
+  let allianceLabel = "";
+    switch (ministry.toLocaleLowerCase()) {
+      case "ag":
+      case "pssg":
+      case "embc":
+      case "mah":
+        allianceLabel = "JAG";
+        break;
       default:
-        return 'none';
+        allianceLabel = "none";
+        break;
     }
-  });
 
   const primaryTechnicalLeadContact = {
     user_id: primaryTechnicalLead.githubId,
@@ -86,7 +87,7 @@ function message(action, requestedProject) {
       snapshot: { count: quota.snapshotCount }
     }
   }));
-
+  
   const request = {
     action: RequestType[action],
     profile_id: id,
@@ -96,7 +97,7 @@ function message(action, requestedProject) {
     description: description,
     ministry_id: ministry,
     merge_type: "auto", // Make this a variable
-    alliance: allianceLabel(), // "JAG" for Justice Attornies Group, else "none"
+    alliance: allianceLabel, // "JAG" for Justice Attornies Group, else "none"
     namespaces,
     contacts: [
       projectOwnerContact,

--- a/src/nats/message.ts
+++ b/src/nats/message.ts
@@ -26,6 +26,8 @@ function message(action, requestedProject) {
     role: "owner"
   };
 
+  const allianceLabel = (ministry as string).toLocaleLowerCase() == 'ag' ? "JAG" : "none";
+
   const primaryTechnicalLeadContact = {
     user_id: primaryTechnicalLead.githubId,
     provider: "github",
@@ -84,6 +86,7 @@ function message(action, requestedProject) {
     description: description,
     ministry_id: ministry,
     merge_type: "auto", // Make this a variable
+    alliance: allianceLabel, // "JAG" for Justice Attornies Group, else "none"
     namespaces,
     contacts: [
       projectOwnerContact,

--- a/src/nats/message.ts
+++ b/src/nats/message.ts
@@ -26,7 +26,17 @@ function message(action, requestedProject) {
     role: "owner"
   };
 
-  const allianceLabel = (ministry as string).toLocaleLowerCase() == 'ag' ? "JAG" : "none";
+  const allianceLabel = (() => {
+    switch ((ministry as string).toLocaleLowerCase()) {
+      case 'ag':
+      case 'pssg':
+      case 'embc':
+      case 'mah':
+        return 'JAG';
+      default:
+        return 'none';
+    }
+  });//ministry as string).toLocaleLowerCase() == 'ag' ? "JAG" : "none";
 
   const primaryTechnicalLeadContact = {
     user_id: primaryTechnicalLead.githubId,
@@ -86,7 +96,7 @@ function message(action, requestedProject) {
     description: description,
     ministry_id: ministry,
     merge_type: "auto", // Make this a variable
-    alliance: allianceLabel, // "JAG" for Justice Attornies Group, else "none"
+    alliance: allianceLabel(), // "JAG" for Justice Attornies Group, else "none"
     namespaces,
     contacts: [
       projectOwnerContact,


### PR DESCRIPTION
based on this task: https://app.zenhub.com/workspaces/platform-experience-5bb7c5ab4b5806bc2beb9d15/issues/gh/bcdevops/developer-experience/2926

All this does is add an "alliance" parameter to the NATS json created when a project is created or updated. It's added right below "merge_type"

It works by just checking the ministry NATS/message.ts, line 29:
```const allianceLabel = (ministry as string).toLocaleLowerCase() == 'ag' ? "JAG" : "none";```

and then on line 89 with the rest of the JSON data:
```  alliance: allianceLabel, // "JAG" for Justice Attornies Group, else "none"```