### PR TITLE
emails improvements, reject email before provisioning

### DIFF
--- a/src/ches/emailHandlers.ts
+++ b/src/ches/emailHandlers.ts
@@ -53,10 +53,11 @@ export const generateEmailTemplateData = (
   const requestedProject = incomingRequest
     ? { ...incomingRequest }
     : { ...incomingProject };
-
-  const projectOwner = project.projectOwner;
-  const primaryTechnicalLead = project.primaryTechnicalLead;
-  const secondaryTechnicalLead = project.secondaryTechnicalLead;
+    
+  const secondaryTechnicalLead = requestedProject.secondaryTechnicalLead !== project.secondaryTechnicalLead ? 
+  requestedProject.secondaryTechnicalLead ? requestedProject.secondaryTechnicalLead : project.secondaryTechnicalLead:null;
+  const primaryTechnicalLead = requestedProject.primaryTechnicalLead;
+  const projectOwner = requestedProject.projectOwner;
 
   project.testQuota = {
     cpu: DefaultCpuOptions[project.testQuota.cpu],
@@ -542,6 +543,57 @@ export const sendProvisionedEmails = async (request) => {
         } request has been rejected`,
       });
     }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+
+export const sendRejectEmail = async (request) => {
+  let { type, requestedProject, humanComment, project } =
+    request;
+
+  if (!project) {
+    project = requestedProject;
+  }
+console.log('project', project)
+console.log('requestedProject', requestedProject)
+  try {
+      chesService.send({
+        bodyType: "html",
+        body: swig.renderFile(
+          "./src/ches/new-templates/request-denial-email.html",
+          generateEmailTemplateData(project, requestedProject, {
+            requestType:
+              type === RequestType.Create
+                ? "Provisioning"
+                : type === RequestType.Edit
+                ? "Edit"
+                : "Deletion",
+            humanActionComment: humanComment || null,
+            isProvisioningRequest: type === RequestType.Create,
+            isQuotaRequest: type === RequestType.Edit,
+            productDescription: requestedProject.description,
+            productMinistry: requestedProject.ministry,
+          })
+        ),
+        // to all project contacts when any request (quota, provisioning, or deletion) is denied.
+        to: [
+          project.projectOwner,
+          project.primaryTechnicalLead,
+          project.secondaryTechnicalLead,
+        ]
+          .filter(Boolean)
+          .map(({ email }) => email),
+        from: "Registry <PlatformServicesTeam@gov.bc.ca>",
+        subject: ` ${
+          type === RequestType.Create
+            ? "Provisioning"
+            : type === RequestType.Edit
+            ? "Edit"
+            : "Deletion"
+        } request has been rejected`,
+      });
   } catch (error) {
     console.error(error);
   }

--- a/src/resolvers/mutations/privateCloudRequestDecision.ts
+++ b/src/resolvers/mutations/privateCloudRequestDecision.ts
@@ -70,7 +70,7 @@ const privateCloudRequestDecision: MutationResolvers = async (
       await sendNatsMessage(request.type, request.requestedProject);
     }
   }
- request.decisionStatus === RequestDecision.Rejected&&sendRejectEmail(request)
+ if(request.decisionStatus === RequestDecision.Rejected)sendRejectEmail(request)
   return request;
 };
 

--- a/src/resolvers/mutations/privateCloudRequestDecision.ts
+++ b/src/resolvers/mutations/privateCloudRequestDecision.ts
@@ -70,7 +70,7 @@ const privateCloudRequestDecision: MutationResolvers = async (
       await sendNatsMessage(request.type, request.requestedProject);
     }
   }
- if(request.decisionStatus === RequestDecision.Rejected)sendRejectEmail(request)
+  if (request.decisionStatus === RequestDecision.Rejected) sendRejectEmail(request)
   return request;
 };
 

--- a/src/resolvers/mutations/privateCloudRequestDecision.ts
+++ b/src/resolvers/mutations/privateCloudRequestDecision.ts
@@ -7,6 +7,7 @@ import {
 } from "../../__generated__/resolvers-types.js";
 import { Prisma } from "@prisma/client";
 import sendNatsMessage from "../../nats/sendNatsMessage.js";
+import { sendRejectEmail } from "../../ches/emailHandlers.js";
 
 const privateCloudRequestDecision: MutationResolvers = async (
   _,
@@ -69,6 +70,7 @@ const privateCloudRequestDecision: MutationResolvers = async (
       await sendNatsMessage(request.type, request.requestedProject);
     }
   }
+ request.decisionStatus === RequestDecision.Rejected&&sendRejectEmail(request)
   return request;
 };
 


### PR DESCRIPTION
Reject email doesn't need to be provisioned, so the function was taken back to C:\Users\Zhanna\Documents\platform-services-registry-api\src\resolvers\mutations\privateCloudRequestDecision.ts while approval emails are sending after being provisioned 