### PR TITLE
removed test prefix from licence plate generator

### DIFF
--- a/src/utils/generateLicencePlate.ts
+++ b/src/utils/generateLicencePlate.ts
@@ -1,10 +1,7 @@
 import crypto from "crypto";
 
 const generateLicensePlate = (len = 6) => {
-  const prefix = process.env.NODE_ENV !== "production" ? "t" : "";
-
   const getRandomPrefix = (requiredLength) =>
-    prefix +
     crypto
       .randomBytes(Math.ceil(requiredLength / 2))
       .toString("hex")


### PR DESCRIPTION
Generating a license plate in our test namespace would result in the licence plait being prefixed with a "t". This was done so that the production provisioner can recognize the project as a test project. 

We now have a designated provisioner instance in the test namespace, so there is no need for this anymore. 