### PR TITLE
Updated API to use new Prisma db schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "add-existing-public-cloud-projects": "dotenv -e .env -- node ./dist/scripts/newPublicCloudProjects/index.js",
     "update-users": "dotenv -e .env -- node ./dist/scripts/updateUsers/index.js",
     "idir-upn-users-update": "dotenv -e .env -- node ./dist/scripts/idirUpnUserUpdate/index.js",
-    "update-creation-dates": "dotenv -e .env -- node ./dist/scripts/updateCreationDates/index.js"
+    "update-creation-dates": "dotenv -e .env -- node ./dist/scripts/updateCreationDates/index.js",
+    "update-common-components": "dotenv -e .env -- node ./dist/scripts/updateCommonComponents/index.js",
+    "update-requests": "dotenv -e .env -- node ./dist/scripts/updateRequests/index.js"
   },
   "keywords": [],
   "author": "",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,8 +2,8 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["extendedWhereUnique", "fullTextIndex"]
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x", "debian-openssl-3.0.x"]
 }
 
 datasource db {
@@ -16,9 +16,10 @@ model User {
   firstName                                          String?
   lastName                                           String?
   email                                              String                         @unique
-  ministry                                           String?
   upn                                                String?
   idir                                               String?
+  image                                              String?
+  ministry                                           String?
   archived                                           Boolean                        @default(false)
   created                                            DateTime                       @default(now())
   lastSeen                                           DateTime                       @updatedAt
@@ -38,20 +39,22 @@ model User {
 }
 
 model PrivateCloudRequest {
-  id                 String                       @id @default(auto()) @map("_id") @db.ObjectId
-  licencePlate       String
-  createdByEmail     String
-  decisionMakerEmail String?
-  type               RequestType
-  decisionStatus     DecisionStatus
-  humanComment       String?
-  active             Boolean                      @default(true)
-  created            DateTime                     @default(now())
-  decisionDate       DateTime?
-  projectId          String?                      @db.ObjectId
-  project            PrivateCloudProject?         @relation("privateCloudProject", fields: [projectId], references: [id])
-  requestedProjectId String                       @unique @db.ObjectId
-  requestedProject   PrivateCloudRequestedProject @relation("privateCloudRequestedProject", fields: [requestedProjectId], references: [id])
+  id                     String                        @id @default(auto()) @map("_id") @db.ObjectId
+  licencePlate           String
+  createdByEmail         String
+  decisionMakerEmail     String?
+  type                   RequestType
+  decisionStatus         DecisionStatus
+  humanComment           String?
+  active                 Boolean                       @default(true)
+  created                DateTime                      @default(now())
+  decisionDate           DateTime?
+  projectId              String?                       @db.ObjectId
+  project                PrivateCloudProject?          @relation("privateCloudProject", fields: [projectId], references: [id], onDelete: Cascade)
+  requestedProjectId     String                        @unique @db.ObjectId
+  requestedProject       PrivateCloudRequestedProject  @relation("privateCloudRequestedProject", fields: [requestedProjectId], references: [id], onDelete: Cascade)
+  userRequestedProjectId String                        @unique @db.ObjectId
+  userRequestedProject   PrivateCloudRequestedProject? @relation("privateCloudUserRequestedProject", fields: [userRequestedProjectId], references: [id], onDelete: Cascade)
 }
 
 model PrivateCloudProject {
@@ -62,11 +65,11 @@ model PrivateCloudProject {
   status                   ProjectStatus
   created                  DateTime              @default(now())
   projectOwnerId           String                @db.ObjectId
-  projectOwner             User                  @relation("privateCloudProjectOwner", fields: [projectOwnerId], references: [id])
+  projectOwner             User                  @relation("privateCloudProjectOwner", fields: [projectOwnerId], references: [id], onDelete: Cascade)
   primaryTechnicalLeadId   String                @db.ObjectId
-  primaryTechnicalLead     User                  @relation("privateCloudPrimaryTechnicalLead", fields: [primaryTechnicalLeadId], references: [id])
+  primaryTechnicalLead     User                  @relation("privateCloudPrimaryTechnicalLead", fields: [primaryTechnicalLeadId], references: [id], onDelete: Cascade)
   secondaryTechnicalLeadId String?               @db.ObjectId
-  secondaryTechnicalLead   User?                 @relation("privateCloudSecondaryTechnicalLead", fields: [secondaryTechnicalLeadId], references: [id])
+  secondaryTechnicalLead   User?                 @relation("privateCloudSecondaryTechnicalLead", fields: [secondaryTechnicalLeadId], references: [id], onDelete: Cascade)
   ministry                 Ministry
   cluster                  Cluster
   productionQuota          Quota
@@ -74,7 +77,6 @@ model PrivateCloudProject {
   developmentQuota         Quota
   toolsQuota               Quota
   commonComponents         CommonComponents
-  profileId                String?
   requests                 PrivateCloudRequest[] @relation("privateCloudProject")
 }
 
@@ -86,11 +88,11 @@ model PrivateCloudRequestedProject {
   licencePlate             String
   created                  DateTime             @default(now())
   projectOwnerId           String               @db.ObjectId
-  projectOwner             User                 @relation("privateCloudRequestedProjectOwner", fields: [projectOwnerId], references: [id])
+  projectOwner             User                 @relation("privateCloudRequestedProjectOwner", fields: [projectOwnerId], references: [id], onDelete: Cascade)
   primaryTechnicalLeadId   String               @db.ObjectId
-  primaryTechnicalLead     User                 @relation("privateCloudRequestedPrimaryTechnicalLead", fields: [primaryTechnicalLeadId], references: [id])
+  primaryTechnicalLead     User                 @relation("privateCloudRequestedPrimaryTechnicalLead", fields: [primaryTechnicalLeadId], references: [id], onDelete: Cascade)
   secondaryTechnicalLeadId String?              @db.ObjectId
-  secondaryTechnicalLead   User?                @relation("privateCloudRequestedSecondaryTechnicalLead", fields: [secondaryTechnicalLeadId], references: [id])
+  secondaryTechnicalLead   User?                @relation("privateCloudRequestedSecondaryTechnicalLead", fields: [secondaryTechnicalLeadId], references: [id], onDelete: Cascade)
   ministry                 Ministry
   cluster                  Cluster
   productionQuota          Quota
@@ -98,25 +100,27 @@ model PrivateCloudRequestedProject {
   developmentQuota         Quota
   toolsQuota               Quota
   commonComponents         CommonComponents
-  profileId                String?
   requestedProject         PrivateCloudRequest? @relation("privateCloudRequestedProject")
+  userRequestedProject     PrivateCloudRequest? @relation("privateCloudUserRequestedProject")
 }
 
 model PublicCloudRequest {
-  id                 String                      @id @default(auto()) @map("_id") @db.ObjectId
-  licencePlate       String
-  createdByEmail     String
-  decisionMakerEmail String?
-  type               RequestType
-  decisionStatus     DecisionStatus
-  humanComment       String?
-  active             Boolean                     @default(true)
-  created            DateTime                    @default(now())
-  decisionDate       DateTime?
-  projectId          String?                     @db.ObjectId
-  project            PublicCloudProject?         @relation("publicCloudProject", fields: [projectId], references: [id])
-  requestedProjectId String                      @unique @db.ObjectId
-  requestedProject   PublicCloudRequestedProject @relation("publicCloudRequestedProject", fields: [requestedProjectId], references: [id])
+  id                     String                       @id @default(auto()) @map("_id") @db.ObjectId
+  licencePlate           String
+  createdByEmail         String
+  decisionMakerEmail     String?
+  type                   PublicCloudRequestType
+  decisionStatus         DecisionStatus
+  humanComment           String?
+  active                 Boolean                      @default(true)
+  created                DateTime                     @default(now())
+  decisionDate           DateTime?
+  projectId              String?                      @db.ObjectId
+  project                PublicCloudProject?          @relation("publicCloudProject", fields: [projectId], references: [id], onDelete: Cascade)
+  requestedProjectId     String                       @unique @db.ObjectId
+  requestedProject       PublicCloudRequestedProject  @relation("publicCloudRequestedProject", fields: [requestedProjectId], references: [id], onDelete: Cascade)
+  userRequestedProjectId String                       @unique @db.ObjectId
+  userRequestedProject   PublicCloudRequestedProject? @relation("publicCloudUserRequestedProject", fields: [userRequestedProjectId], references: [id], onDelete: Cascade)
 }
 
 model PublicCloudProject {
@@ -129,11 +133,11 @@ model PublicCloudProject {
   accountCoding            String
   budget                   Budget
   projectOwnerId           String               @db.ObjectId
-  projectOwner             User                 @relation("publicCloudProjectOwner", fields: [projectOwnerId], references: [id])
+  projectOwner             User                 @relation("publicCloudProjectOwner", fields: [projectOwnerId], references: [id], onDelete: Cascade)
   primaryTechnicalLeadId   String               @db.ObjectId
-  primaryTechnicalLead     User                 @relation("publicCloudPrimaryTechnicalLead", fields: [primaryTechnicalLeadId], references: [id])
+  primaryTechnicalLead     User                 @relation("publicCloudPrimaryTechnicalLead", fields: [primaryTechnicalLeadId], references: [id], onDelete: Cascade)
   secondaryTechnicalLeadId String?              @db.ObjectId
-  secondaryTechnicalLead   User?                @relation("publicCloudSecondaryTechnicalLead", fields: [secondaryTechnicalLeadId], references: [id])
+  secondaryTechnicalLead   User?                @relation("publicCloudSecondaryTechnicalLead", fields: [secondaryTechnicalLeadId], references: [id], onDelete: Cascade)
   ministry                 Ministry
   provider                 Provider
   requests                 PublicCloudRequest[] @relation("publicCloudProject")
@@ -149,41 +153,46 @@ model PublicCloudRequestedProject {
   accountCoding            String
   budget                   Budget
   projectOwnerId           String              @db.ObjectId
-  projectOwner             User                @relation("publicCloudRequestedProjectOwner", fields: [projectOwnerId], references: [id])
+  projectOwner             User                @relation("publicCloudRequestedProjectOwner", fields: [projectOwnerId], references: [id], onDelete: Cascade)
   primaryTechnicalLeadId   String              @db.ObjectId
-  primaryTechnicalLead     User                @relation("publicCloudRequestedPrimaryTechnicalLead", fields: [primaryTechnicalLeadId], references: [id])
+  primaryTechnicalLead     User                @relation("publicCloudRequestedPrimaryTechnicalLead", fields: [primaryTechnicalLeadId], references: [id], onDelete: Cascade)
   secondaryTechnicalLeadId String?             @db.ObjectId
-  secondaryTechnicalLead   User?               @relation("publicCloudRequestedSecondaryTechnicalLead", fields: [secondaryTechnicalLeadId], references: [id])
+  secondaryTechnicalLead   User?               @relation("publicCloudRequestedSecondaryTechnicalLead", fields: [secondaryTechnicalLeadId], references: [id], onDelete: Cascade)
   ministry                 Ministry
   provider                 Provider
-  // commonComponents         CommonComponents
   requestedProject         PublicCloudRequest? @relation("publicCloudRequestedProject")
+  userRequestedProject     PublicCloudRequest? @relation("publicCloudUserRequestedProject")
 }
 
 type Quota {
-  cpu     DefaultCpuOptions
-  memory  DefaultMemoryOptions
-  storage DefaultStorageOptions
+  cpu     String
+  memory  String
+  storage String
 }
 
 type Budget {
-  dev   Float
-  test  Float
-  prod  Float
-  tools Float
+  dev   Int
+  test  Int
+  prod  Int
+  tools Int
+}
+
+type CommonComponentsOptions {
+  planningToUse Boolean
+  implemented   Boolean
 }
 
 type CommonComponents {
-  addressAndGeolocation              CommonComponentsOptions?
-  workflowManagement                 CommonComponentsOptions?
-  formDesignAndSubmission            CommonComponentsOptions?
-  identityManagement                 CommonComponentsOptions?
-  paymentServices                    CommonComponentsOptions?
-  documentManagement                 CommonComponentsOptions?
-  endUserNotificationAndSubscription CommonComponentsOptions?
-  publishing                         CommonComponentsOptions?
-  businessIntelligence               CommonComponentsOptions?
-  other                              String?
+  addressAndGeolocation              CommonComponentsOptions
+  workflowManagement                 CommonComponentsOptions
+  formDesignAndSubmission            CommonComponentsOptions
+  identityManagement                 CommonComponentsOptions
+  paymentServices                    CommonComponentsOptions
+  documentManagement                 CommonComponentsOptions
+  endUserNotificationAndSubscription CommonComponentsOptions
+  publishing                         CommonComponentsOptions
+  businessIntelligence               CommonComponentsOptions
+  other                              String
   noServices                         Boolean
 }
 
@@ -205,11 +214,10 @@ enum RequestType {
   DELETE
 }
 
-// enum PublicCloudRequestType {
-//   CREATE
-//   EDIT
-//   DELETE
-// }
+enum PublicCloudRequestType {
+  CREATE
+  EDIT
+}
 
 enum Ministry {
   AEST
@@ -254,41 +262,4 @@ enum Cluster {
 enum Provider {
   GOOGLE
   AWS
-}
-
-enum DefaultCpuOptions {
-  CPU_REQUEST_0_5_LIMIT_1_5
-  CPU_REQUEST_1_LIMIT_2
-  CPU_REQUEST_2_LIMIT_4
-  CPU_REQUEST_4_LIMIT_8
-  CPU_REQUEST_8_LIMIT_16
-  CPU_REQUEST_16_LIMIT_32
-  CPU_REQUEST_32_LIMIT_64
-  CPU_REQUEST_64_LIMIT_128
-}
-
-enum CommonComponentsOptions {
-  IMPLEMENTED
-  PLANNING_TO_USE
-}
-
-enum DefaultMemoryOptions {
-  MEMORY_REQUEST_2_LIMIT_4
-  MEMORY_REQUEST_4_LIMIT_8
-  MEMORY_REQUEST_8_LIMIT_16
-  MEMORY_REQUEST_16_LIMIT_32
-  MEMORY_REQUEST_32_LIMIT_64
-  MEMORY_REQUEST_64_LIMIT_128
-}
-
-enum DefaultStorageOptions {
-  STORAGE_1
-  STORAGE_2
-  STORAGE_4
-  STORAGE_16
-  STORAGE_32
-  STORAGE_64
-  STORAGE_128
-  STORAGE_256
-  STORAGE_512
 }

--- a/src/resolvers/mutations/privateCloud/createRequest.ts
+++ b/src/resolvers/mutations/privateCloud/createRequest.ts
@@ -44,6 +44,46 @@ const privateCloudProjectRequest: MutationResolvers['privateCloudProjectRequest'
 
     let createRequest;
 
+    const requestedProject = {
+      name: args.name,
+      description: args.description,
+      cluster: args.cluster,
+      ministry: args.ministry,
+      status: ProjectStatus.Active,
+      licencePlate: licencePlate,
+      commonComponents: transformCommonComponents(args.commonComponents),
+      productionQuota: defaultQuota,
+      testQuota: defaultQuota,
+      toolsQuota: defaultQuota,
+      developmentQuota: defaultQuota,
+      projectOwner: {
+        connectOrCreate: {
+          where: {
+            email: args.projectOwner.email,
+          },
+          create: args.projectOwner,
+        },
+      },
+      primaryTechnicalLead: {
+        connectOrCreate: {
+          where: {
+            email: args.primaryTechnicalLead.email,
+          },
+          create: args.primaryTechnicalLead,
+        },
+      },
+      secondaryTechnicalLead: args.secondaryTechnicalLead
+        ? {
+            connectOrCreate: {
+              where: {
+                email: args.secondaryTechnicalLead.email,
+              },
+              create: args.secondaryTechnicalLead,
+            },
+          }
+        : undefined,
+    };
+
     try {
       createRequest = await prisma.privateCloudRequest.create({
         data: {
@@ -52,47 +92,14 @@ const privateCloudProjectRequest: MutationResolvers['privateCloudProjectRequest'
           active: true,
           createdByEmail: authEmail,
           licencePlate,
+          userRequestedProject: {
+            create: {
+              ...requestedProject,
+            },
+          },
           requestedProject: {
             create: {
-              name: args.name,
-              description: args.description,
-              cluster: args.cluster,
-              ministry: args.ministry,
-              status: ProjectStatus.Active,
-              licencePlate: licencePlate,
-              commonComponents: transformCommonComponents(
-                args.commonComponents
-              ),
-              productionQuota: defaultQuota,
-              testQuota: defaultQuota,
-              toolsQuota: defaultQuota,
-              developmentQuota: defaultQuota,
-              projectOwner: {
-                connectOrCreate: {
-                  where: {
-                    email: args.projectOwner.email,
-                  },
-                  create: args.projectOwner,
-                },
-              },
-              primaryTechnicalLead: {
-                connectOrCreate: {
-                  where: {
-                    email: args.primaryTechnicalLead.email,
-                  },
-                  create: args.primaryTechnicalLead,
-                },
-              },
-              secondaryTechnicalLead: args.secondaryTechnicalLead
-                ? {
-                    connectOrCreate: {
-                      where: {
-                        email: args.secondaryTechnicalLead.email,
-                      },
-                      create: args.secondaryTechnicalLead,
-                    },
-                  }
-                : undefined,
+              ...requestedProject,
             },
           },
         },

--- a/src/resolvers/mutations/privateCloud/createRequest.ts
+++ b/src/resolvers/mutations/privateCloud/createRequest.ts
@@ -12,6 +12,7 @@ import {
 import generateLicensePlate from '../../../utils/generateLicencePlate.js';
 import { Prisma } from '@prisma/client';
 import { sendCreateRequestEmails } from '../../../ches/emailHandlersPrivate.js';
+import { transformCommonComponents } from '../../../utils/transformCommonComponents.js';
 
 const privateCloudProjectRequest: MutationResolvers['privateCloudProjectRequest'] =
   async (
@@ -19,7 +20,6 @@ const privateCloudProjectRequest: MutationResolvers['privateCloudProjectRequest'
     args: MutationPrivateCloudProjectRequestArgs,
     { authRoles, authEmail, prisma }
   ) => {
-
     // Check if the user is allowed to create a project
     if (
       ![
@@ -60,7 +60,9 @@ const privateCloudProjectRequest: MutationResolvers['privateCloudProjectRequest'
               ministry: args.ministry,
               status: ProjectStatus.Active,
               licencePlate: licencePlate,
-              commonComponents: args.commonComponents,
+              commonComponents: transformCommonComponents(
+                args.commonComponents
+              ),
               productionQuota: defaultQuota,
               testQuota: defaultQuota,
               toolsQuota: defaultQuota,

--- a/src/resolvers/mutations/privateCloud/deleteRequest.ts
+++ b/src/resolvers/mutations/privateCloud/deleteRequest.ts
@@ -103,6 +103,9 @@ const privateCloudProjectDeleteRequest: MutationResolvers = async (
         active: true,
         createdByEmail: authEmail,
         licencePlate: project.licencePlate,
+        userRequestedProject: {
+          create: project,
+        },
         requestedProject: {
           create: project,
         },

--- a/src/resolvers/mutations/privateCloud/editRequest.ts
+++ b/src/resolvers/mutations/privateCloud/editRequest.ts
@@ -9,6 +9,7 @@ import { Prisma, PrivateCloudRequest } from '@prisma/client';
 import { sendPrivateCloudNatsMessage } from '../../../natsPubSub/index.js';
 import { sendEditRequestEmails } from '../../../ches/emailHandlersPrivate.js';
 import { subscribeUserToMessages } from '../../../mautic/index.js';
+import { transformCommonComponents } from '../../../utils/transformCommonComponents.js';
 
 const privateCloudProjectEditRequest: MutationResolvers['privateCloudProjectEditRequest'] =
   async (
@@ -69,12 +70,11 @@ const privateCloudProjectEditRequest: MutationResolvers['privateCloudProjectEdit
         ministry: args.ministry,
         status: project.status,
         licencePlate: project.licencePlate,
-        commonComponents: args.commonComponents,
+        commonComponents: transformCommonComponents(args.commonComponents),
         productionQuota: args.productionQuota,
         testQuota: args.testQuota,
         toolsQuota: args.toolsQuota,
         developmentQuota: args.developmentQuota,
-        profileId: project.profileId || null,
         created: project.created,
         projectOwner: {
           connectOrCreate: {
@@ -94,23 +94,22 @@ const privateCloudProjectEditRequest: MutationResolvers['privateCloudProjectEdit
         },
         secondaryTechnicalLead: args.secondaryTechnicalLead
           ? {
-            connectOrCreate: {
-              where: {
-                email: args.secondaryTechnicalLead.email,
+              connectOrCreate: {
+                where: {
+                  email: args.secondaryTechnicalLead.email,
+                },
+                create: args.secondaryTechnicalLead,
               },
-              create: args.secondaryTechnicalLead,
-            },
-          }
+            }
           : undefined,
       };
 
-
       const isQuotaChanged = !(
         JSON.stringify(args.productionQuota) ===
-        JSON.stringify(project.productionQuota) &&
+          JSON.stringify(project.productionQuota) &&
         JSON.stringify(args.testQuota) === JSON.stringify(project.testQuota) &&
         JSON.stringify(args.developmentQuota) ===
-        JSON.stringify(project.developmentQuota) &&
+          JSON.stringify(project.developmentQuota) &&
         JSON.stringify(args.toolsQuota) === JSON.stringify(project.toolsQuota)
       );
 
@@ -160,7 +159,6 @@ const privateCloudProjectEditRequest: MutationResolvers['privateCloudProjectEdit
         editRequest.requestedProject
       );
 
-
       if (decisionStatus === DecisionStatus.Approved) {
         const users = [
           args.projectOwner,
@@ -168,7 +166,11 @@ const privateCloudProjectEditRequest: MutationResolvers['privateCloudProjectEdit
           args?.secondaryTechnicalLead,
         ].filter(Boolean);
 
-        Promise.all(users.map((user) => subscribeUserToMessages(user, requestedProject.cluster, "Private")));
+        Promise.all(
+          users.map((user) =>
+            subscribeUserToMessages(user, requestedProject.cluster, 'Private')
+          )
+        );
 
         await sendPrivateCloudNatsMessage(
           editRequest.type,

--- a/src/resolvers/mutations/privateCloud/editRequest.ts
+++ b/src/resolvers/mutations/privateCloud/editRequest.ts
@@ -130,6 +130,9 @@ const privateCloudProjectEditRequest: MutationResolvers['privateCloudProjectEdit
           requestedProject: {
             create: requestedProject,
           },
+          userRequestedProject: {
+            create: requestedProject,
+          },
           project: {
             connect: {
               id: args.projectId,

--- a/src/resolvers/mutations/privateCloud/reProvisionProject.ts
+++ b/src/resolvers/mutations/privateCloud/reProvisionProject.ts
@@ -98,6 +98,9 @@ const privateCloudReProvisionProject: MutationResolvers['privateCloudReProvision
           requestedProject: {
             create: requestedProject,
           },
+          userRequestedProject: {
+            create: requestedProject,
+          },
           project: {
             connect: {
               id: args.projectId,

--- a/src/resolvers/mutations/privateCloud/reProvisionProject.ts
+++ b/src/resolvers/mutations/privateCloud/reProvisionProject.ts
@@ -59,7 +59,6 @@ const privateCloudReProvisionProject: MutationResolvers['privateCloudReProvision
         testQuota: project.testQuota,
         toolsQuota: project.toolsQuota,
         developmentQuota: project.developmentQuota,
-        profileId: project.profileId || null,
         created: project.created,
         projectOwner: {
           connectOrCreate: {

--- a/src/resolvers/mutations/publicCloud/createRequest.ts
+++ b/src/resolvers/mutations/publicCloud/createRequest.ts
@@ -88,6 +88,9 @@ const publicCloudProjectRequest = async (
     requestedProject: {
       create: requestedProject,
     },
+    userRequestedProject: {
+      create: requestedProject,
+    },
   };
 
   let createRequest: PublicCloudCreateRequest;

--- a/src/resolvers/mutations/publicCloud/deleteRequest.ts
+++ b/src/resolvers/mutations/publicCloud/deleteRequest.ts
@@ -1,130 +1,131 @@
 import {
-    MutationResolvers,
-    ProjectStatus,
-    RequestType,
-    DecisionStatus,
-    MutationPublicCloudProjectDeleteRequestArgs,
-  } from '../../../__generated__/resolvers-types.js';
-  import { sendDeleteRequestEmails } from '../../../ches/emailHandlersPublic.js';
-  import { Prisma, PublicCloudProject } from '@prisma/client';
-  import { sendPublicCloudNatsMessage } from '../../../natsPubSub/index.js';
+  MutationResolvers,
+  ProjectStatus,
+  RequestType,
+  DecisionStatus,
+  MutationPublicCloudProjectDeleteRequestArgs,
+} from '../../../__generated__/resolvers-types.js';
+import { sendDeleteRequestEmails } from '../../../ches/emailHandlersPublic.js';
+import { Prisma, PublicCloudProject } from '@prisma/client';
+import { sendPublicCloudNatsMessage } from '../../../natsPubSub/index.js';
 
-  
-  const publicCloudProjectDeleteRequest: MutationResolvers = async (
-    _,
-    args: MutationPublicCloudProjectDeleteRequestArgs,
-    { authRoles, authEmail, prisma }
-  ) => {
-    let deleteRequest;
-  
-    try {
-      // Check if the user has inputed the correct arguments to delete a project
-      const { id, ...project }: PublicCloudProject =
-        await prisma.publicCloudProject.findUniqueOrThrow({
-          where: {
-            id: args.projectId,
-            licencePlate: args.licencePlate,
-            status: ProjectStatus.Active,
-          },
-        });
-        
-      // Make sure there are no other projects with the same licence plate
-      const projects = await prisma.publicCloudProject.findMany({
+const publicCloudProjectDeleteRequest: MutationResolvers = async (
+  _,
+  args: MutationPublicCloudProjectDeleteRequestArgs,
+  { authRoles, authEmail, prisma }
+) => {
+  let deleteRequest;
+
+  try {
+    // Check if the user has inputed the correct arguments to delete a project
+    const { id, ...project }: PublicCloudProject =
+      await prisma.publicCloudProject.findUniqueOrThrow({
         where: {
+          id: args.projectId,
           licencePlate: args.licencePlate,
+          status: ProjectStatus.Active,
         },
       });
-  
-      if (projects.length > 1) {
-        throw new Error(
-          'There are multiple projects with this licence plate. This is an error.'
-        );
-      }
-      
-      // Check if the user inputed the correct project owner email in the delete form
-      const projectOwner = await prisma.user.findUnique({
-        where: {
-          id: project.projectOwnerId,
-        },
-      });
-  
-      if (args.projectOwnerEmail !== projectOwner.email) {
-        throw new Error(
-          'The project owner email does not match the email of the project owner.'
-        );
-      }
-  
-      // Check if the user is allowed to delete the project
-      const users = await prisma.user.findMany({
-        where: {
-          id: {
-            in: [
-              project.projectOwnerId,
-              project.primaryTechnicalLeadId,
-              project.secondaryTechnicalLeadId,
-            ].filter(Boolean),
-          },
-        },
-        select: {
-          email: true,
-        },
-      });
-  
-      if (
-        !users.map((user) => user.email).includes(authEmail) &&
-        !authRoles.includes('admin')
-      ) {
-        throw new Error(
-          'You need to be a contact on this project in order to delete it.'
-        );
-      }
-  
-      project.status = ProjectStatus.Inactive;
-  
-      deleteRequest = await prisma.publicCloudRequest.create({
-        data: {
-          type: RequestType.Delete,
-          decisionStatus: DecisionStatus.Approved,
-          active: true,
-          createdByEmail: authEmail,
-          licencePlate: project.licencePlate,
-          requestedProject: {
-            create: project,
-          },
-          project: {
-            connect: {
-              id: args.projectId,
-            },
-          },
-        },
-        include: {
-          project: {
-            include: {
-              projectOwner: true,
-              primaryTechnicalLead: true,
-              secondaryTechnicalLead: true,
-            },
-          },
-        },
-      });
-      await sendPublicCloudNatsMessage(
-        deleteRequest.type,
-        deleteRequest.project,
-        deleteRequest.project,
+
+    // Make sure there are no other projects with the same licence plate
+    const projects = await prisma.publicCloudProject.findMany({
+      where: {
+        licencePlate: args.licencePlate,
+      },
+    });
+
+    if (projects.length > 1) {
+      throw new Error(
+        'There are multiple projects with this licence plate. This is an error.'
       );
-      sendDeleteRequestEmails(deleteRequest.project);
-    } catch (e) {
-      if (e instanceof Prisma.PrismaClientKnownRequestError) {
-        if (e.code === 'P2002') {
-          throw new Error('There is already an active request for this project.');
-        }
-      }
-      console.log(e);
-      throw new Error('This project did not pass the deletion checks. ' + e);
     }
-  
-    return deleteRequest;
-  };
-  
-  export default publicCloudProjectDeleteRequest;
-  
+
+    // Check if the user inputed the correct project owner email in the delete form
+    const projectOwner = await prisma.user.findUnique({
+      where: {
+        id: project.projectOwnerId,
+      },
+    });
+
+    if (args.projectOwnerEmail !== projectOwner.email) {
+      throw new Error(
+        'The project owner email does not match the email of the project owner.'
+      );
+    }
+
+    // Check if the user is allowed to delete the project
+    const users = await prisma.user.findMany({
+      where: {
+        id: {
+          in: [
+            project.projectOwnerId,
+            project.primaryTechnicalLeadId,
+            project.secondaryTechnicalLeadId,
+          ].filter(Boolean),
+        },
+      },
+      select: {
+        email: true,
+      },
+    });
+
+    if (
+      !users.map((user) => user.email).includes(authEmail) &&
+      !authRoles.includes('admin')
+    ) {
+      throw new Error(
+        'You need to be a contact on this project in order to delete it.'
+      );
+    }
+
+    project.status = ProjectStatus.Inactive;
+
+    deleteRequest = await prisma.publicCloudRequest.create({
+      data: {
+        type: RequestType.Delete,
+        decisionStatus: DecisionStatus.Approved,
+        active: true,
+        createdByEmail: authEmail,
+        licencePlate: project.licencePlate,
+        requestedProject: {
+          create: project,
+        },
+        userRequestedProject: {
+          create: project,
+        },
+        project: {
+          connect: {
+            id: args.projectId,
+          },
+        },
+      },
+      include: {
+        project: {
+          include: {
+            projectOwner: true,
+            primaryTechnicalLead: true,
+            secondaryTechnicalLead: true,
+          },
+        },
+      },
+    });
+    await sendPublicCloudNatsMessage(
+      deleteRequest.type,
+      deleteRequest.project,
+      deleteRequest.project
+    );
+    sendDeleteRequestEmails(deleteRequest.project);
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError) {
+      if (e.code === 'P2002') {
+        throw new Error('There is already an active request for this project.');
+      }
+    }
+    console.log(e);
+    throw new Error('This project did not pass the deletion checks. ' + e);
+  }
+
+  return deleteRequest;
+};
+
+export default publicCloudProjectDeleteRequest;

--- a/src/resolvers/mutations/publicCloud/editRequest.ts
+++ b/src/resolvers/mutations/publicCloud/editRequest.ts
@@ -132,6 +132,9 @@ const publicCloudProjectEditRequest = async (
         id: args.projectId,
       },
     },
+    userRequestedProject: {
+      create: requestedProject,
+    },
   };
 
   let editRequest: PublicCloudEditRequest;

--- a/src/resolvers/privateCloudProject.ts
+++ b/src/resolvers/privateCloudProject.ts
@@ -1,3 +1,5 @@
+import { revertCommonComponents } from '../utils/transformCommonComponents.js';
+
 const Project = {
   projectOwner: async (project, _, { prisma }) =>
     prisma.user.findUnique({
@@ -32,6 +34,8 @@ const Project = {
         projectId: project.id,
       },
     }),
+  commonComponents: async (project) =>
+    revertCommonComponents(project.commonComponents),
 };
 
 export default Project;

--- a/src/resolvers/privateCloudProject.ts
+++ b/src/resolvers/privateCloudProject.ts
@@ -34,8 +34,11 @@ const Project = {
         projectId: project.id,
       },
     }),
-  commonComponents: async (project) =>
-    revertCommonComponents(project.commonComponents),
+  commonComponents: async (project) => {
+    const restult = revertCommonComponents(project.commonComponents);
+    console.log('restult: ', restult);
+    return restult;
+  },
 };
 
 export default Project;

--- a/src/scripts/updateCommonComponents/index.ts
+++ b/src/scripts/updateCommonComponents/index.ts
@@ -1,4 +1,5 @@
 import { MongoClient } from 'mongodb';
+import { Prisma, CommonComponents } from '@prisma/client';
 
 function tranformCommonComponentOption(original) {
   if (original === undefined || original === null) {
@@ -24,7 +25,7 @@ function tranformCommonComponentOption(original) {
   }
 }
 
-const transformCommonComponents = (originalComponents) => {
+export const transformCommonComponents = (originalComponents: any) => {
   const commonComponentKeys = [
     'addressAndGeolocation',
     'workflowManagement',
@@ -35,8 +36,6 @@ const transformCommonComponents = (originalComponents) => {
     'endUserNotificationAndSubscription',
     'publishing',
     'businessIntelligence',
-    'other',
-    'noServices',
   ];
 
   const commonComponetsOptions = Object.fromEntries(
@@ -46,16 +45,22 @@ const transformCommonComponents = (originalComponents) => {
     ])
   );
 
-  return {
+  const isCommonComponentsUsed = !Object.values(commonComponetsOptions).some(
+    (value) => value.planningToUse || value.implemented
+  );
+
+  const newComponents = {
     ...commonComponetsOptions,
     other: originalComponents.other || '',
-    noServices: originalComponents.noServices || true,
-  };
-};
+    noServices: isCommonComponentsUsed,
+  } as CommonComponents;
 
+  return newComponents;
+};
 // Connection URL and Database Name
 const url = process.env.DATABASE_URL;
-const dbName = 'platsrv-registry-db';
+// const dbName = 'platsrv-registry-db';
+const dbName = 'oamar';
 const collectionNames = ['PrivateCloudRequestedProject', 'PrivateCloudProject'];
 
 console.log('DATABASE_URL: ', url);
@@ -64,39 +69,6 @@ console.log('DATABASE_URL: ', url);
 const client = new MongoClient(url);
 
 async function updateDocuments(collectionName) {
-  try {
-    // Connect the client to the server
-    await client.connect();
-    console.log('Connected successfully to server');
-
-    // Get the database and collection
-    const db = client.db(dbName);
-    const collection = db.collection(collectionName);
-
-    // Get all documents
-    const cursor = collection.find({}); // Adjust the find query as needed
-
-    console.log('Found documents:', await cursor.count());
-
-    // Iterate over the cursor
-    for await (const project of cursor) {
-      const commonComponents = transformCommonComponents(
-        project.commonComponents
-      );
-
-      // Update the document
-      await collection.updateOne(
-        { _id: project._id }, // Make sure to use the correct identifier field
-        { $set: { commonComponents } }
-      );
-    }
-  } finally {
-    // Ensures that the client will close when you finish/error
-    await client.close();
-  }
-}
-
-async function addUserRequestedProject(collectionName) {
   try {
     // Connect the client to the server
     await client.connect();

--- a/src/scripts/updateCommonComponents/index.ts
+++ b/src/scripts/updateCommonComponents/index.ts
@@ -60,7 +60,7 @@ export const transformCommonComponents = (originalComponents: any) => {
 // Connection URL and Database Name
 const url = process.env.DATABASE_URL;
 // const dbName = 'platsrv-registry-db';
-const dbName = 'oamar';
+const dbName = 'test-new-schema';
 const collectionNames = ['PrivateCloudRequestedProject', 'PrivateCloudProject'];
 
 console.log('DATABASE_URL: ', url);

--- a/src/scripts/updateCommonComponents/index.ts
+++ b/src/scripts/updateCommonComponents/index.ts
@@ -1,0 +1,113 @@
+import { MongoClient } from 'mongodb';
+import { collect } from 'nats/lib/nats-base-client/util';
+
+export const transformCommonComponents = (originalComponents) =>
+  Object.keys(originalComponents).reduce((accumulator, key) => {
+    if (
+      (typeof originalComponents[key] === 'string' ||
+        originalComponents[key] === null) &&
+      key !== 'other'
+    ) {
+      accumulator[key] = {
+        planningToUse: originalComponents[key] === 'PLANNING_TO_USE',
+        implemented: false,
+      };
+    } else {
+      // Directly copy non-string and non-null values
+      accumulator[key] = originalComponents[key];
+    }
+
+    accumulator['other'] === null
+      ? (accumulator['other'] = '')
+      : (accumulator['other'] = accumulator['other']);
+
+    return accumulator;
+  }, {});
+
+// Connection URL and Database Name
+const url = process.env.DATABASE_URL;
+const dbName = 'restore';
+const collectionNames = ['PrivateCloudRequestedProject', 'PrivateCloudProject'];
+
+console.log('DATABASE_URL: ', url);
+
+// Create a new MongoClient
+const client = new MongoClient(url);
+
+async function updateDocuments(collectionName) {
+  try {
+    // Connect the client to the server
+    await client.connect();
+    console.log('Connected successfully to server');
+
+    // Get the database and collection
+    const db = client.db(dbName);
+    const collection = db.collection(collectionName);
+
+    // Get all documents
+    const cursor = collection.find({}); // Adjust the find query as needed
+
+    console.log('Found documents:', await cursor.count());
+
+    // Iterate over the cursor
+    for await (const project of cursor) {
+      const commonComponents = transformCommonComponents(
+        project.commonComponents
+      );
+
+      // Update the document
+      await collection.updateOne(
+        { _id: project._id }, // Make sure to use the correct identifier field
+        { $set: { commonComponents } }
+      );
+    }
+  } finally {
+    // Ensures that the client will close when you finish/error
+    await client.close();
+  }
+}
+
+async function addUserRequestedProject(collectionName) {
+  try {
+    // Connect the client to the server
+    await client.connect();
+    console.log('Connected successfully to server');
+
+    // Get the database and collection
+    const db = client.db(dbName);
+    const collection = db.collection(collectionName);
+
+    // Get all documents
+    const cursor = collection.find({}); // Adjust the find query as needed
+
+    console.log('Found documents:', await cursor.count());
+
+    // Iterate over the cursor
+    for await (const project of cursor) {
+      const commonComponents = transformCommonComponents(
+        project.commonComponents
+      );
+
+      // Update the document
+      await collection.updateOne(
+        { _id: project._id }, // Make sure to use the correct identifier field
+        { $set: { commonComponents } }
+      );
+    }
+  } finally {
+    // Ensures that the client will close when you finish/error
+    await client.close();
+  }
+}
+
+// Call the updateDocuments function
+async function updateAllCollections(collections) {
+  for (const collectionName of collections) {
+    await updateDocuments(collectionName);
+  }
+}
+
+// Call the updateAllCollections function with all collection names
+updateAllCollections(collectionNames)
+  .then(() => console.log('All collections have been updated.'))
+  .catch((error) => console.error('Error updating collections:', error));

--- a/src/scripts/updateCommonComponents/index.ts
+++ b/src/scripts/updateCommonComponents/index.ts
@@ -1,62 +1,6 @@
 import { MongoClient } from 'mongodb';
-import { Prisma, CommonComponents } from '@prisma/client';
+import { transformCommonComponents } from '../../utils/transformCommonComponents';
 
-function tranformCommonComponentOption(original) {
-  if (original === undefined || original === null) {
-    return {
-      planningToUse: false,
-      implemented: false,
-    };
-  } else if (original === 'PLANNING_TO_USE') {
-    return {
-      planningToUse: true,
-      implemented: false,
-    };
-  } else if (original === 'IMPLEMENTED') {
-    return {
-      planningToUse: false,
-      implemented: true,
-    };
-  } else {
-    return {
-      planningToUse: false,
-      implemented: false,
-    };
-  }
-}
-
-export const transformCommonComponents = (originalComponents: any) => {
-  const commonComponentKeys = [
-    'addressAndGeolocation',
-    'workflowManagement',
-    'formDesignAndSubmission',
-    'identityManagement',
-    'paymentServices',
-    'documentManagement',
-    'endUserNotificationAndSubscription',
-    'publishing',
-    'businessIntelligence',
-  ];
-
-  const commonComponetsOptions = Object.fromEntries(
-    commonComponentKeys.map((key) => [
-      key,
-      tranformCommonComponentOption(originalComponents[key]),
-    ])
-  );
-
-  const isCommonComponentsUsed = !Object.values(commonComponetsOptions).some(
-    (value) => value.planningToUse || value.implemented
-  );
-
-  const newComponents = {
-    ...commonComponetsOptions,
-    other: originalComponents.other || '',
-    noServices: isCommonComponentsUsed,
-  } as CommonComponents;
-
-  return newComponents;
-};
 // Connection URL and Database Name
 const url = process.env.DATABASE_URL;
 // const dbName = 'platsrv-registry-db';

--- a/src/scripts/updateCommonComponents/index.ts
+++ b/src/scripts/updateCommonComponents/index.ts
@@ -25,7 +25,7 @@ async function updateDocuments(collectionName) {
     // Get all documents
     const cursor = collection.find({}); // Adjust the find query as needed
 
-    console.log('Found documents:', await cursor.count());
+    console.log('Found documents:', await collection.countDocuments());
 
     // Iterate over the cursor
     for await (const project of cursor) {

--- a/src/scripts/updateRequests/index.ts
+++ b/src/scripts/updateRequests/index.ts
@@ -2,7 +2,7 @@ import { MongoClient } from 'mongodb';
 
 // Connection URL and Database Name
 const url = process.env.DATABASE_URL;
-const dbName = 'platsrv-registry-db';
+const dbName = 'test-new-schema';
 const collectionNames = ['PrivateCloudRequest', 'PublicCloudRequest'];
 
 console.log('DATABASE_URL: ', url);

--- a/src/scripts/updateRequests/index.ts
+++ b/src/scripts/updateRequests/index.ts
@@ -2,7 +2,7 @@ import { MongoClient } from 'mongodb';
 
 // Connection URL and Database Name
 const url = process.env.DATABASE_URL;
-const dbName = 'restore';
+const dbName = 'platsrv-registry-db';
 const collectionNames = ['PrivateCloudRequest', 'PublicCloudRequest'];
 
 console.log('DATABASE_URL: ', url);

--- a/src/scripts/updateRequests/index.ts
+++ b/src/scripts/updateRequests/index.ts
@@ -1,0 +1,52 @@
+import { MongoClient } from 'mongodb';
+
+// Connection URL and Database Name
+const url = process.env.DATABASE_URL;
+const dbName = 'restore';
+const collectionNames = ['PrivateCloudRequest', 'PublicCloudRequest'];
+
+console.log('DATABASE_URL: ', url);
+
+// Create a new MongoClient
+const client = new MongoClient(url);
+
+async function updateDocuments(collectionName) {
+  try {
+    // Connect the client to the server
+    await client.connect();
+    console.log('Connected successfully to server');
+
+    // Get the database and collection
+    const db = client.db(dbName);
+    const collection = db.collection(collectionName);
+
+    // Get all documents
+    const cursor = collection.find({}); // Adjust the find query as needed
+
+    console.log('Found documents:', await collection.countDocuments());
+
+    // Iterate over the cursor
+    for await (const request of cursor) {
+      // Update the document
+      await collection.updateOne(
+        { _id: request._id }, // Make sure to use the correct identifier field
+        { $set: { userRequestedProjectId: request.requestedProjectId } }
+      );
+    }
+  } finally {
+    // Ensures that the client will close when you finish/error
+    await client.close();
+  }
+}
+
+// Call the updateDocuments function
+async function updateAllCollections(collections) {
+  for (const collectionName of collections) {
+    await updateDocuments(collectionName);
+  }
+}
+
+// Call the updateAllCollections function with all collection names
+updateAllCollections(collectionNames)
+  .then(() => console.log('All collections have been updated.'))
+  .catch((error) => console.error('Error updating collections:', error));

--- a/src/utils/transformCommonComponents.ts
+++ b/src/utils/transformCommonComponents.ts
@@ -1,0 +1,34 @@
+export const transformCommonComponents = (originalComponents) =>
+  Object.keys(originalComponents).reduce((accumulator, key) => {
+    if (
+      typeof originalComponents[key] === 'string' ||
+      originalComponents[key] === null
+    ) {
+      accumulator[key] = {
+        planningToUse: originalComponents[key] === 'PLANNING_TO_USE',
+        implemented: false,
+      };
+    } else {
+      // Directly copy non-string and non-null values
+      accumulator[key] = originalComponents[key];
+    }
+    return accumulator;
+  }, {});
+
+export function revertCommonComponents(structured) {
+  return Object.keys(structured).reduce((accumulator, key) => {
+    const value = structured[key];
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      'planningToUse' in value
+    ) {
+      // Assume that if planningToUse is true, we don't care about the implemented flag.
+      accumulator[key] = value.planningToUse ? 'PLANNING_TO_USE' : 'NOT_USING';
+    } else {
+      // Directly copy non-object values
+      accumulator[key] = value;
+    }
+    return accumulator;
+  }, {});
+}

--- a/src/utils/transformCommonComponents.ts
+++ b/src/utils/transformCommonComponents.ts
@@ -6,22 +6,26 @@ function tranformCommonComponentOption(original) {
       planningToUse: false,
       implemented: false,
     };
-  } else if (original === 'PLANNING_TO_USE') {
+  }
+
+  if (original === 'PLANNING_TO_USE') {
     return {
       planningToUse: true,
       implemented: false,
     };
-  } else if (original === 'IMPLEMENTED') {
+  }
+
+  if (original === 'IMPLEMENTED') {
     return {
       planningToUse: false,
       implemented: true,
     };
-  } else {
-    return {
-      planningToUse: false,
-      implemented: false,
-    };
   }
+
+  return {
+    planningToUse: false,
+    implemented: false,
+  };
 }
 
 export const transformCommonComponents = (originalComponents: any) => {
@@ -74,7 +78,9 @@ export const revertCommonComponents = (transformedComponents) => {
       // Handle the 'other' and 'noServices' keys separately if needed
       if (key === 'other') {
         return [key, value || null]; // Convert empty string back to null
-      } else if (key === 'noServices') {
+      }
+
+      if (key === 'noServices') {
         return [key, value !== undefined ? value : false]; // Preserve boolean or default to false
       }
       // Reverse transform the common component options

--- a/src/utils/transformCommonComponents.ts
+++ b/src/utils/transformCommonComponents.ts
@@ -1,3 +1,5 @@
+import { CommonComponents } from '@prisma/client';
+
 function tranformCommonComponentOption(original) {
   if (original === undefined || original === null) {
     return {
@@ -22,7 +24,7 @@ function tranformCommonComponentOption(original) {
   }
 }
 
-export const transformCommonComponents = (originalComponents) => {
+export const transformCommonComponents = (originalComponents: any) => {
   const commonComponentKeys = [
     'addressAndGeolocation',
     'workflowManagement',
@@ -33,8 +35,6 @@ export const transformCommonComponents = (originalComponents) => {
     'endUserNotificationAndSubscription',
     'publishing',
     'businessIntelligence',
-    'other',
-    'noServices',
   ];
 
   const commonComponetsOptions = Object.fromEntries(
@@ -44,11 +44,17 @@ export const transformCommonComponents = (originalComponents) => {
     ])
   );
 
-  return {
+  const isCommonComponentsUsed = !Object.values(commonComponetsOptions).some(
+    (value) => value.planningToUse || value.implemented
+  );
+
+  const newComponents = {
     ...commonComponetsOptions,
     other: originalComponents.other || '',
-    noServices: originalComponents.noServices || true,
-  };
+    noServices: isCommonComponentsUsed,
+  } as CommonComponents;
+
+  return newComponents;
 };
 
 function reverseTransformCommonComponentOption(option) {


### PR DESCRIPTION
- Updated api with the new prisma db schema
- Patched the registry api to transform common components to the new format in the db schema. Incoming data will be transformed to the new format and outgoing data will be transformed back to the old format. This way we do not need to make any changes on the front end
- Created two scripts to a) Convert common components to the new format and b) Add a `userRequestedProjectId` to a PrivateCloudRequest as to conform with the new db schema

These changes will ensure that the current registry is compatible with the new db schema and can operate along side the new registry.