### PR TITLE
Update Dockerfile to node:18.18.2-alpine3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18.18.2-alpine3.18
 
 ARG NODE_MAJOR_VERSION=18
-ARG NODE_VERSION=16.18.2
+ARG NODE_VERSION=18.18.2
 
 RUN mkdir /var/opt/build
 WORKDIR /var/opt/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:16.15.0-alpine
+FROM node:18.18.2-alpine3.18
 
-ARG NODE_MAJOR_VERSION=16
-ARG NODE_VERSION=16.15.0
+ARG NODE_MAJOR_VERSION=18
+ARG NODE_VERSION=16.18.2
 
 RUN mkdir /var/opt/build
 WORKDIR /var/opt/build


### PR DESCRIPTION
Api is crash looping with this log:

```
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /.npm
npm ERR! errno -13
npm ERR!
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR!
npm ERR! To permanently fix this problem, please run:
npm ERR! sudo chown -R 1005160000:0 "/.npm"
```

This PR is a potential fix